### PR TITLE
feat: Add disposable email check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ version = "0.3.2"
 dependencies = [
  "lettre 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mailchecker 3.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -663,6 +664,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mailchecker"
+version = "3.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fast_chemail 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1751,6 +1760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+"checksum mailchecker 3.2.35 (registry+https://github.com/rust-lang/crates.io-index)" = "fb9afee880495a318a969aff310e081614a6c229d10bd0ab73d7ca78ae9b6437"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "check_if_email_exists"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
- "check_if_email_exists_core 0.3.2",
+ "check_if_email_exists_core 0.4.0",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "check_if_email_exists_core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "lettre 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "check_if_email_exists_serverless"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
- "check_if_email_exists_core 0.3.2",
+ "check_if_email_exists_core 0.4.0",
  "lambda_http 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_runtime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "check_if_email_exists_test_suite"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
- "check_if_email_exists_core 0.3.2",
+ "check_if_email_exists_core 0.4.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check_if_email_exists"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Amaury Martiny <amaury.martiny@protonmail.com>"]
 description = "Check if an email address exists without sending any email"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The output will be a JSON with the following format, for `someone@gmail.com` (no
 ```json
 {
 	"mx": {
+		"is_disposable": false,
 		"records": [
 			"alt3.gmail-smtp-in.l.google.com.",
 			"gmail-smtp-in.l.google.com.",
@@ -56,9 +57,9 @@ The output will be a JSON with the following format, for `someone@gmail.com` (no
 		]
 	},
 	"smtp": {
-		"deliverable": false,
-		"full_inbox": false,
-		"has_catch_all": false
+		"has_full_inbox": false,
+		"is_catch_all": false,
+		"is_deliverable": false
 	},
 	"syntax": {
 		"address": "someone@gmail.com",

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ The output will be a JSON with the following format, for `someone@gmail.com` (no
 	"smtp": {
 		"has_full_inbox": false,
 		"is_catch_all": false,
-		"is_deliverable": false
+		"is_deliverable": false,
+		"is_disabled": true,
 	},
 	"syntax": {
 		"address": "someone@gmail.com",

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -18,8 +18,8 @@ main() {
     # aka some quick e2e test on the binary itself
     # TODO This only works on osx now, see #11
     if [ $TRAVIS_OS_NAME = osx ]; then
-        cross run --target $TARGET $TEST_EMAIL | grep "\"deliverable\": true"
-        cross run --target $TARGET --release $TEST_EMAIL | grep "\"deliverable\": true"
+        cross run --target $TARGET $TEST_EMAIL | grep "\"is_deliverable\": true"
+        cross run --target $TARGET --release $TEST_EMAIL | grep "\"is_deliverable\": true"
     fi
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check_if_email_exists_core"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Amaury Martiny <amaury.martiny@protonmail.com>"]
 description = "Check if an email address exists without sending any email"
 edition = "2018"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 lettre = "0.9"
 log = "0.4"
+mailchecker = "3.2"
 native-tls = "^0.2"
 rand = "0.7"
 rayon = "1.2.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,6 +17,7 @@
 extern crate lettre;
 #[macro_use]
 extern crate log;
+extern crate mailchecker;
 extern crate native_tls;
 extern crate rand;
 extern crate rayon;
@@ -97,7 +98,7 @@ pub fn email_exists(to_email: &str, from_email: &str) -> SingleEmail {
 	debug!("Details of the email address: {:?}", my_syntax);
 
 	debug!("Getting MX lookup...");
-	let my_mx = match get_mx_lookup(&my_syntax.domain) {
+	let my_mx = match get_mx_lookup(&my_syntax) {
 		Ok(m) => m,
 		e => {
 			return SingleEmail {
@@ -112,7 +113,7 @@ pub fn email_exists(to_email: &str, from_email: &str) -> SingleEmail {
 	// `(host, port)` combination
 	// We could add ports 465 and 587 too
 	let combinations = my_mx
-		.0
+		.lookup
 		.iter()
 		.map(|host| (host.exchange(), SMTP_PORT))
 		.collect::<Vec<_>>();

--- a/core/src/smtp.rs
+++ b/core/src/smtp.rs
@@ -30,12 +30,12 @@ use trust_dns_resolver::Name;
 /// Details that we gathered from connecting to this email via SMTP
 #[derive(Debug, Serialize)]
 pub struct SmtpDetails {
-	/// Can we send an email to this address?
-	pub deliverable: bool,
 	/// Is this email account's inbox full?
-	pub full_inbox: bool,
+	pub has_full_inbox: bool,
+	/// Can we send an email to this address?
+	pub is_deliverable: bool,
 	/// Does this domain have a catch-all email address?
-	pub has_catch_all: bool,
+	pub is_catch_all: bool,
 }
 
 /// Error occured connecting to this email server via SMTP
@@ -181,8 +181,8 @@ pub fn smtp_details(
 ) -> Result<SmtpDetails, LettreSmtpError> {
 	let mut smtp_client = connect_to_host(from_email, host, port)?;
 
-	let has_catch_all = email_has_catch_all(&mut smtp_client, domain).unwrap_or(false);
-	let (deliverable, full_inbox) = match email_deliverable(&mut smtp_client, to_email) {
+	let is_catch_all = email_has_catch_all(&mut smtp_client, domain).unwrap_or(false);
+	let (is_deliverable, has_full_inbox) = match email_deliverable(&mut smtp_client, to_email) {
 		Ok(exists) => (exists, false),
 		Err(err) => {
 			let err_string = err.to_string();
@@ -205,8 +205,8 @@ pub fn smtp_details(
 	smtp_client.close();
 
 	Ok(SmtpDetails {
-		deliverable,
-		full_inbox,
-		has_catch_all,
+		has_full_inbox,
+		is_deliverable,
+		is_catch_all,
 	})
 }

--- a/core/src/smtp.rs
+++ b/core/src/smtp.rs
@@ -32,10 +32,12 @@ use trust_dns_resolver::Name;
 pub struct SmtpDetails {
 	/// Is this email account's inbox full?
 	pub has_full_inbox: bool,
-	/// Can we send an email to this address?
-	pub is_deliverable: bool,
 	/// Does this domain have a catch-all email address?
 	pub is_catch_all: bool,
+	/// Can we send an email to this address?
+	pub is_deliverable: bool,
+	/// Is the email blocked or disabled by the provider?
+	pub is_disabled: bool,
 }
 
 /// Error occured connecting to this email server via SMTP
@@ -108,11 +110,20 @@ fn connect_to_host(
 	Ok(smtp_client)
 }
 
+struct Deliverability {
+	/// Is this email account's inbox full?
+	pub has_full_inbox: bool,
+	/// Can we send an email to this address?
+	is_deliverable: bool,
+	/// Is the email blocked or disabled by the provider?
+	is_disabled: bool,
+}
+
 /// Check if `to_email` exists on host server with given port
 fn email_deliverable(
 	smtp_client: &mut InnerClient<NetworkStream>,
 	to_email: &EmailAddress,
-) -> Result<bool, LettreSmtpError> {
+) -> Result<Deliverability, LettreSmtpError> {
 	// "RCPT TO: me@email.com"
 	// FIXME Do not clone?
 	let to_email = to_email.clone();
@@ -121,7 +132,11 @@ fn email_deliverable(
 			Some(message) => {
 				if message.contains("2.1.5") {
 					// 250 2.1.5 Recipient e-mail address ok.
-					Ok(true)
+					Ok(Deliverability {
+						has_full_inbox: false,
+						is_deliverable: true,
+						is_disabled: false,
+					})
 				} else {
 					Err(LettreSmtpError::Client("Can't find 2.1.5 in RCPT command"))
 				}
@@ -132,6 +147,31 @@ fn email_deliverable(
 			let err_string = err.to_string();
 			// Don't return an error if the error contains anything about the
 			// address being undeliverable
+
+			// Check if the email account has been disabled or blocked
+			// e.g. "The email account that you tried to reach is disabled. Learn more at https://support.google.com/mail/?p=DisabledUser"
+			if err_string.contains("disabled") || err_string.contains("blocked") {
+				return Ok(Deliverability {
+					has_full_inbox: false,
+					is_deliverable: false,
+					is_disabled: true,
+				});
+			}
+
+			// Check if the email account has a full inbox
+			if err_string.contains("full")
+				|| err_string.contains("insufficient")
+				|| err_string.contains("over quota")
+				|| err_string.contains("space")
+			{
+				return Ok(Deliverability {
+					has_full_inbox: true,
+					is_deliverable: false,
+					is_disabled: false,
+				});
+			}
+
+			// These are the possible error messages when email account doesn't exist
 			if err_string.contains("address rejected")
 				|| err_string.contains("does not exist")
 				|| err_string.contains("invalid address")
@@ -142,13 +182,16 @@ fn email_deliverable(
 				|| err_string.contains("undeliverable")
 				|| err_string.contains("user unknown")
 				|| err_string.contains("user not found")
-				// The email account that you tried to reach is disabled. Learn more at https://support.google.com/mail/?p=DisabledUser
 				|| err_string.contains("disabled")
 			{
-				Ok(false)
-			} else {
-				Err(err)
+				return Ok(Deliverability {
+					has_full_inbox: false,
+					is_deliverable: false,
+					is_disabled: false,
+				});
 			}
+
+			Err(err)
 		}
 	}
 }
@@ -169,6 +212,7 @@ fn email_has_catch_all(
 		smtp_client,
 		&random_email.expect("Email is correctly constructed. qed."),
 	)
+	.map(|deliverability| deliverability.is_deliverable)
 }
 
 /// Get all email details we can.
@@ -182,31 +226,14 @@ pub fn smtp_details(
 	let mut smtp_client = connect_to_host(from_email, host, port)?;
 
 	let is_catch_all = email_has_catch_all(&mut smtp_client, domain).unwrap_or(false);
-	let (is_deliverable, has_full_inbox) = match email_deliverable(&mut smtp_client, to_email) {
-		Ok(exists) => (exists, false),
-		Err(err) => {
-			let err_string = err.to_string();
-			// These messages mean that inbox is full, which also means that
-			// email exists
-			if err_string.contains("full")
-				|| err_string.contains("insufficient")
-				|| err_string.contains("over quota")
-				|| err_string.contains("space")
-			{
-				(true, true)
-			} else {
-				debug!("Closing {}:{}, because of error '{}'.", host, port, err);
-				return Err(err);
-			}
-		}
-	};
+	let deliverability = email_deliverable(&mut smtp_client, to_email)?;
 
-	// Quit.
 	smtp_client.close();
 
 	Ok(SmtpDetails {
-		has_full_inbox,
-		is_deliverable,
+		has_full_inbox: deliverability.has_full_inbox,
 		is_catch_all,
+		is_deliverable: deliverability.is_deliverable,
+		is_disabled: deliverability.is_disabled,
 	})
 }

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check_if_email_exists_serverless"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Amaury Martiny <amaury.martiny@protonmail.com>"]
 description = "Check if an email address exists without sending any email"
 edition = "2018"

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,5 +1,5 @@
 name: check_if_email_exists
-version: '0.3.2'
+version: '0.4.0'
 author: Amaury Martiny <amaury.martiny@protonmail.com>
 about: Check if an email address exists without sending any email.
 args:

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,9 +20,9 @@ extern crate serde;
 
 use check_if_email_exists_core::email_exists;
 use clap::App;
-use serde_json::Result as JsonResult;
+use serde_json;
 
-fn main() -> JsonResult<()> {
+fn main() -> serde_json::Result<()> {
 	env_logger::init();
 
 	// The YAML file is found relative to the current file, similar to how modules are found

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check_if_email_exists_test_suite"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Amaury Martiny <amaury.martiny@protonmail.com>"]
 description = "Check if an email address exists without sending any email"
 edition = "2018"

--- a/test_suite/src/lib.rs
+++ b/test_suite/src/lib.rs
@@ -35,13 +35,4 @@ mod tests {
 			"{\"mx\":{\"error\":{\"type\":\"ResolveError\",\"message\":\"no record found for name: bar.baz type: MX class: IN\"}},\"smtp\":{\"error\":{\"type\":\"Skipped\"}},\"syntax\":{\"address\":\"foo@bar.baz\",\"domain\":\"bar.baz\",\"username\":\"foo\",\"valid_format\":true}}"
 		);
 	}
-
-	#[test]
-	#[ignore]
-	fn should_output_error_when_blocked_by_isp() {
-		assert_eq!(
-			serde_json::to_string(&email_exists("someone@fastmail.com", "user@example.org")).unwrap(),
-			"{\"mx\":{\"records\":[\"in1-smtp.messagingengine.com.\",\"in2-smtp.messagingengine.com.\"]},\"smtp\":{\"error\":{\"type\":\"BlockedByIsp\"}},\"syntax\":{\"address\":\"someone@fastmail.com\",\"domain\":\"fastmail.com\",\"username\":\"someone\",\"valid_format\":true}}"
-		);
-	}
 }


### PR DESCRIPTION
the `mx` object contains a new field `is_disposable`

BREAKING CHANGE: the `smtp`'s object keys have changed. Instead of
```
{
  "deliverable": ...,
  "full_inbox": ...,
  "has_catch_all": ...
}
```
it now returns 
```
{
  "has_full_inbox": ...,
  "is_deliverable": ...,
  "is_disabled": ...,
  "is_catch_all": ...
}
```
where `is_disabled` checks if the address has been disabled/blocked by the email provider